### PR TITLE
Fix About dialog in Firefox and use CSS for Layout and checkboxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,8 +21,8 @@
 
              https://github.com/GoogleChrome/dialog-polyfill
            -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.4/dialog-polyfill.min.js"></script>
-        <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.4/dialog-polyfill.min.css" />
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.9/dialog-polyfill.min.js"></script>
+        <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.9/dialog-polyfill.min.css" />
 
         <!-- Event.focusin
              Polyfill required for Firefox to support focusin and focusout events

--- a/src/Reactor.elm
+++ b/src/Reactor.elm
@@ -23,9 +23,9 @@ main =
                     [ Material.Scheme.topWithScheme Color.Cyan Color.LightBlue (Html.div [] [])
                     , View.view model
                     , Html.node "script" [ Html.attribute "src" "https://cdn.polyfill.io/v2/polyfill.js?features=Event.focusin" ] []
-                    , Html.node "script" [ Html.attribute "src" "https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.4/dialog-polyfill.min.js" ] []
+                    , Html.node "script" [ Html.attribute "src" "https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.9/dialog-polyfill.min.js" ] []
                     , Html.node "link"
-                        [ Html.attribute "href" "https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.4/dialog-polyfill.min.css"
+                        [ Html.attribute "href" "https://cdnjs.cloudflare.com/ajax/libs/dialog-polyfill/0.4.9/dialog-polyfill.min.css"
                         , Html.attribute "rel" "stylesheet"
                         , Html.attribute "type" "text/css"
                         ]

--- a/src/View.elm
+++ b/src/View.elm
@@ -19,8 +19,8 @@ import Charts
 import Material.Scheme
 
 
-styles : String
-styles =
+stylesheet : Html a
+stylesheet = Options.stylesheet
     """
    .demo-options .mdl-checkbox__box-outline {
       border-color: rgba(255, 255, 255, 0.89);
@@ -52,7 +52,8 @@ view model =
                 , drawer = [ drawerHeader model, viewDrawer model ]
                 , tabs = ( [], [] )
                 , main =
-                    [ viewBody model
+                    [ stylesheet
+                    , viewBody model
                     , Snackbar.view model.snackbar |> Html.map Snackbar
                     , viewSource model
                     , helpDialog model


### PR DESCRIPTION
Hi,

dialog-polyfill-0.4.6 fixes unresponsive About dialog in Firefox 58, but 0.4.9 has few more fixes and doesn't seem to break anything so bumped to 0.4.9. With 0.4.4 the dialog itself and "Close" button is under the dialog backdrop and it's impossible to do anything.

And after the upgrade to elm-mdl 8.1.0 embedded CSS in the View.elm got lost (not used anywhere), changing the drawer and checkboxes colors. So restore CSS.

Thanks for a very useful example!